### PR TITLE
Optimised last_file_open

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -8,7 +8,7 @@ import random
 from widgets.Messagebox import MessageBox
 from utils.config import config_reader, config_choice
 from widgets.Tabs import Tabs
-from utils.lastOpenFile import lastFileOpen, updateLastFileOpen
+from utils.last_open_file import update_previous_file, get_last_file
 from widgets.Content import Content
 from widgets.Image import Image
 from utils.find_all_files import DocumentSearch
@@ -27,7 +27,6 @@ os.environ["PYTHONUNBUFFERED"] = "1"
 class Main(QMainWindow):
     def __init__(self, parent=None):
         super().__init__(parent)
-
         self.onStart(choiceIndex)
         self.status = QStatusBar(self)
         # Initializing the main widget where text is displayed
@@ -335,7 +334,7 @@ class Main(QMainWindow):
                 pass
 
             self.tab.setLayout(self.tab.layout)  # Finally we set the layout
-            updateLastFileOpen(filename)
+            update_previous_file(filename)
             self.tab.tabs.setCurrentIndex(index)  # Setting the index so we could find the current widget
 
             self.currentTab = self.tab.tabs.currentWidget()
@@ -431,7 +430,7 @@ class Main(QMainWindow):
                 active_index = self.tab.tabs.currentIndex()
 
                 options = QFileDialog.Options()
-                name = QFileDialog.getSaveFileName(self, 'Save File', '',
+                name = QFileDialog.getSaveFileName(options, 'Save File', '',
                                                    'All Files (*);;Python Files (*.py);;Text Files (*.txt)',
                                                    options=options)
                 fileName = name[0]
@@ -532,7 +531,7 @@ if __name__ == '__main__':
     try:
         file = sys.argv[1]
     except IndexError:  # File not given
-        file = lastFileOpen()
+        file = get_last_file()
 
     app.setStyle('Fusion')
     palette = QPalette()

--- a/src/utils/lastOpenFile.py
+++ b/src/utils/lastOpenFile.py
@@ -1,26 +1,30 @@
 import os
 
+last_file = ['resources/lastFile.txt']
 
-def updateLastFileOpen(filepath):
+def update_previous_file(filepath):
     try:
-        os.path.isfile(filepath)
-    except (FileNotFoundError, PermissionError, OSError):
+        if os.path.isfile(filepath):
+            try:
+                with open('resources/lastFile.txt', 'w+') as file:
+                    file.write(filepath)
+            except (FileNotFoundError, IOError) as err:
+                print(err)
+                return False
+    except Exception as err:
+        print(err)
         return False
-    try:
-        with open('resources/lastFile.txt', 'w') as f:
-            f.write(filepath)
-        return True
-    except FileNotFoundError as E:
-        print(E)
 
 
-def lastFileOpen():
+def get_last_file():
     try:
-        file = open('resources/lastFile.txt', 'r+')
-        try:
-            return file.read().strip()
-        finally:
-            file.close()
-    except (FileNotFoundError, PermissionError, OSError):
-        print('last-file-open config file not found')
-        return None
+        if os.path.isfile(last_file[0]):
+            try:
+                with open(last_file[0], 'r+') as file:
+                    return file.read(50) # Might need to assign more bytes if it reaches limit.
+            except (FileNotFoundError, IOError) as err:
+                print(err)
+                return False
+    except Exception as err:
+        print(err)
+        return False

--- a/src/utils/last_open_file.py
+++ b/src/utils/last_open_file.py
@@ -1,0 +1,31 @@
+import os
+
+last_file = ['resources/lastFile.txt']
+
+
+def update_previous_file(filepath=last_file[0]):
+    try:
+        if os.path.isfile(filepath):
+            try:
+                with open(last_file[0], 'w+') as file:
+                    file.write(filepath)
+            except (FileNotFoundError, IOError) as err:
+                print(err)
+                return False
+    except Exception as err:
+        print(err)
+        return False
+
+
+def get_last_file():
+    try:
+        if os.path.isfile(last_file[0]):
+            try:
+                with open(last_file[0], 'r+') as file:
+                    return file.read(50) # Might need to assign more bytes if it reaches limit.
+            except (FileNotFoundError, IOError) as err:
+                print(err)
+                return False
+    except Exception as err:
+        print(err)
+        return False


### PR DESCRIPTION
This function will now read the file through bytes, this will stop a .txt file that's too large on buffer and crash PyPad (had it happen a few times). Doesn't need to strip the file either, so it's more optimised.